### PR TITLE
Add async HTTP req functionality

### DIFF
--- a/roku-gamp/source/googleAnalytics.brs
+++ b/roku-gamp/source/googleAnalytics.brs
@@ -35,7 +35,7 @@
 '*****************************
 '** Initialization and request firing
 '*****************************
-Function initGAMobile(tracking_ids As Dynamic, client_id As String) As Void
+Function initGAMobile(tracking_ids As Dynamic, client_id As String, mainThreadMsgPort as Object) As Void
   gamobile = CreateObject("roAssociativeArray")
 
   if type(tracking_ids) = "String"
@@ -57,6 +57,10 @@ Function initGAMobile(tracking_ids As Dynamic, client_id As String) As Void
   gamobile.installer_id = device.getModel()
   ' single point of on/off for analytics
   gamobile.enable = false
+  
+  gamobile.pendingReqByUUID = {}    ' Since we async HTTP metric requests, hold onto objects so they dont go out of scope (and get killed)
+  gamobile.mainThreadMsgPort = mainThreadMsgPort    ' Handle HTTP async callbacks in main thread so we don't block
+  
   'set global attributes
   m.gamobile = gamobile
 End Function
@@ -66,6 +70,24 @@ Function enableGAMobile(enable As Boolean) As Void
   m.gamobile.enable = enable
 End Function
 
+Function isGaMobileHttpRequest(requestId as String) as Boolean
+  return m.gamobile.pendingReqByUUID[requestId] <> invalid
+End Function
+
+Function handleGaMobileHttpResponseEvent(event as Object) as void
+  requestId = event.GetSourceIdentity().ToStr()  
+  
+  if isGaMobileHttpRequest(requestId) 'GA async req completed, clean it up
+    httpRc = event.GetResponseCode()
+    m.gamobile.pendingReqByUUID.Delete(requestId)
+  else 
+    ? "[GA] request did not come from GA. requestId: ";requestId    
+  endif  
+End Function
+
+Function getGaPendingRequestsMap() as Object  
+  return m.gamobile.pendingReqByUUID
+End Function
 
 '*****************************
 '** Hit types
@@ -75,7 +97,7 @@ End Function
 '** PageView is primarily intended for web site tracking but is included here for completeness.
 '**
 Function gamobilePageView(hostname="" As String, page="" As String, title="" As String) As Void
-  print "GAnalytics:PageView: " + page
+  ? "[GA] PageView: " + page
 
   params = "&t=pageview"
   params = params + "&dh=" + URLEncode(hostname)   ' Document hostname
@@ -88,7 +110,7 @@ End Function
 '** Use the Event for application state events, such as a login or registration.
 '**
 Function gamobileEvent(category As String, action As String, label="" As String, value="" As String) As Void
-  print "GAnalytics:Event: " + category + "/" + action
+  ? "[GA] Event: " + category + "/" + action
 
   params = "&t=event"
   params = params + "&ec=" + URLEncode(category)   ' Event Category. Required.
@@ -103,7 +125,7 @@ End Function
 '** categories or determining conversion rates for a video stream.
 '**
 Function gamobileScreenView(screen_name As String) As Void
-  print "GAnalytics:Screen: " + screen_name
+  ? "[GA] Screen: " + screen_name
 
   params = "&t=screenview"
   params = params + "&cd=" + URLEncode(screen_name)                ' Screen name / content description.
@@ -116,7 +138,7 @@ End Function
 '**
 '**
 Function gamobileTransaction(transaction_id As String, affiliation="" As String, revenue="" As String, shipping="" As String, tax="" As String) As Void
-  print "GAnalytics:Transaction: " + transaction_id
+  ? "[GA] Transaction: " + transaction_id
 
   params = "&t=transaction"
   params = params + "&ti=" + URLEncode(transaction_id)  ' Transaction ID
@@ -140,7 +162,7 @@ End Function
 '** or misbehaving CDNs.
 '**
 Function gamobileException(description As String) As Void
-  print "GAnalytics:Exception: "
+  ? "[GA] Exception: "
   params = "&t=exception"
   params = params + "&exd=" + URLEncode(description)  ' Exception description.
   params = params + "&exf=0"                          ' Exception is fatal? (we can't capture fatals in brightscript)
@@ -154,7 +176,7 @@ End Function
 ' @params   Stringified, encoded parameters appropriate for the hit. Must start with '&'
 Function gamobileSendHit(hit_params As String) As Void
   if m.gamobile.enable <> true then
-    print "GAnalytics disabled. Skipping report"
+    ? "[GA] disabled. Skipping POST"
     return
   endif
 
@@ -169,17 +191,21 @@ Function gamobileSendHit(hit_params As String) As Void
   full_params = full_params + "&aiid=" + URLEncode(m.gamobile.installer_id)  ' App Installer Id.
   full_params = full_params + hit_params
   full_params = full_params + "&z=" + tostr(m.gamobile.next_z)  ' Cache buster
-
-  request = CreateObject("roURLTransfer")
-  request.SetRequest("POST")
-  
-  request.SetUrl(url)
-  
+   
   For Each tracking_id in m.gamobile.tracking_ids
-    postStr = full_params + "&tid=" + URLEncode(tracking_id)                       
-    ' Synchronously execute the request, ignoring the response
-    rc = request.PostFromString(postStr)
-'    ? "POSTed GA ("+rc.ToStr()+") ";postStr 
+    'New xfer obj needs to be made each request and ref held on to per https://sdkdocs.roku.com/display/sdkdoc/ifUrlTransfer
+    request = CreateObject("roURLTransfer")
+'    request.SetRequest("POST")  
+    request.SetUrl(url)
+    request.SetMessagePort(m.gamobile.mainThreadMsgPort)
+  
+    postStr = full_params + "&tid=" + URLEncode(tracking_id)                           
+    didSend = request.AsyncPostFromString(postStr)        
+    requestId = request.GetIdentity().ToStr()
+    m.gamobile.pendingReqByUUID[requestId] = request
+    
+    ? "[GA] POSTed ("+requestId+")";postStr
+    ' uncomment for debuggin ? "[GA] pending req";getGaPendingRequestsMap()
   End For
   
   ' Increment the cache buster

--- a/roku-gamp/source/googleAnalytics.brs
+++ b/roku-gamp/source/googleAnalytics.brs
@@ -187,7 +187,7 @@ Function gamobileSendHit(hit_params As String) As Void
     requestId = request.GetIdentity().ToStr()
     m.gamobile.asyncReqById[requestId] = request
     
-    ? "[GA]gamobileSendHit POSTed ("+requestId+")";postStr
+    ? "[GA] sendHit POSTed ("+requestId+")";postStr
     ' uncomment for debuggin ? "[GA] pending req";getGaPendingRequestsMap()
   End For
      

--- a/roku-gamp/source/googleAnalytics.brs
+++ b/roku-gamp/source/googleAnalytics.brs
@@ -74,6 +74,7 @@ Function isGaMobileHttpRequest(requestId as String) as Boolean
   return m.gamobile.pendingReqByUUID[requestId] <> invalid
 End Function
 
+' Cleanup resources
 Function handleGaMobileHttpResponseEvent(event as Object) as void
   requestId = event.GetSourceIdentity().ToStr()  
   

--- a/roku-gamp/source/main.brs
+++ b/roku-gamp/source/main.brs
@@ -26,8 +26,6 @@
 '** Application startup
 '************************************************************
 Function Main(args As Dynamic) As void
-    m.port = CreateObject("roMessagePort")  'Need a port to handle GA async HTTP req
-    
     gamobile_tracking_ids = ["tracking-id-here"] ' tracking id for this channel
     device = createObject("roDeviceInfo")
     gamobile_client_id = device.GetPublisherId() 'unique, anonymous, per-device id
@@ -51,19 +49,5 @@ Function Main(args As Dynamic) As void
 
     ' Track a transaction
     gamobileTransaction("Purchase-Code", "", "1.99")
-
-    ' Main event loop    
-    while true
-        msg = wait(0, m.port)        
-        msgType = type(msg)
-        
-        if msgType = "roUrlEvent"            
-            requestId = msg.GetSourceIdentity().ToStr()
-            ? "[Main] got roUrlEvent ";requestId 
-            if isGaMobileHttpRequest(requestId)
-                handleGaMobileHttpResponseEvent(msg)    'This cleans up resources
-            endif                     
-        endif
-    end while
 End Function
 

--- a/roku-gamp/source/main.brs
+++ b/roku-gamp/source/main.brs
@@ -26,13 +26,14 @@
 '** Application startup
 '************************************************************
 Function Main(args As Dynamic) As void
+
     gamobile_tracking_ids = ["tracking-id-here"] ' tracking id for this channel
     device = createObject("roDeviceInfo")
     gamobile_client_id = device.GetPublisherId() 'unique, anonymous, per-device id
     enable_tracking = NOT device.IsAdIdTrackingDisabled() 'setting in Roku menu to limit tracking
 
     ' Init analytics
-    initGAMobile(gamobile_tracking_ids, gamobile_client_id, m.port)
+    initGAMobile(gamobile_tracking_ids, gamobile_client_id)
     if enable_tracking then
       print "Enabling tracking analytics"
       enableGAMobile(true)
@@ -49,5 +50,6 @@ Function Main(args As Dynamic) As void
 
     ' Track a transaction
     gamobileTransaction("Purchase-Code", "", "1.99")
+
 End Function
 

--- a/roku-gamp/source/main.brs
+++ b/roku-gamp/source/main.brs
@@ -26,14 +26,15 @@
 '** Application startup
 '************************************************************
 Function Main(args As Dynamic) As void
-
+    m.port = CreateObject("roMessagePort")  'Need a port to handle GA async HTTP req
+    
     gamobile_tracking_ids = ["tracking-id-here"] ' tracking id for this channel
     device = createObject("roDeviceInfo")
     gamobile_client_id = device.GetPublisherId() 'unique, anonymous, per-device id
     enable_tracking = NOT device.IsAdIdTrackingDisabled() 'setting in Roku menu to limit tracking
 
     ' Init analytics
-    initGAMobile(gamobile_tracking_ids, gamobile_client_id)
+    initGAMobile(gamobile_tracking_ids, gamobile_client_id, m.port)
     if enable_tracking then
       print "Enabling tracking analytics"
       enableGAMobile(true)
@@ -51,5 +52,18 @@ Function Main(args As Dynamic) As void
     ' Track a transaction
     gamobileTransaction("Purchase-Code", "", "1.99")
 
+    ' Main event loop    
+    while true
+        msg = wait(0, m.port)        
+        msgType = type(msg)
+        
+        if msgType = "roUrlEvent"            
+            requestId = msg.GetSourceIdentity().ToStr()
+            ? "[Main] got roUrlEvent ";requestId 
+            if isGaMobileHttpRequest(requestId)
+                handleGaMobileHttpResponseEvent(msg)    'This cleans up resources
+            endif                     
+        endif
+    end while
 End Function
 


### PR DESCRIPTION
This PR does not preserve backwards compat as it breaks existing `initGAMobile()` signature by adding a new `mainThreadMsgPort` param.

However, I feel the breaking change is justified as this is how GA should be used on Roku (best practice is to send Async AND to handle the events in the main event loop).

@silentpickle please code review. I think I was able to pull this off pretty cleanly, while maintaining good performance (I used a map cuz as you mention arrays are slow).

For what is worth, I have this working in a screen graph app on firmware 7.2.2+