### PR TITLE
App name not being correctly populated

### DIFF
--- a/roku-gamp/source/googleAnalytics.brs
+++ b/roku-gamp/source/googleAnalytics.brs
@@ -35,7 +35,7 @@
 '*****************************
 '** Initialization and request firing
 '*****************************
-Function initGAMobile(tracking_ids As Dynamic, client_id As String) As Void
+Function initGAMobile(tracking_ids As Dynamic, client_id As String, app_name_override = "" As string) As Void
   gamobile = CreateObject("roAssociativeArray")
 
   if type(tracking_ids) = "String"
@@ -50,7 +50,11 @@ Function initGAMobile(tracking_ids As Dynamic, client_id As String) As Void
   gamobile.next_z = 1
 
   app_info = CreateObject("roAppInfo")
-  gamobile.app_name = app_info.GetTitle()
+  if app_name_override <> ""
+    gamobile.app_name = app_name_override
+  else
+    gamobile.app_name = app_info.GetTitle()
+  end if
   gamobile.app_version = app_info.GetVersion()
   gamobile.app_id = app_info.GetID()
   device = createObject("roDeviceInfo")


### PR DESCRIPTION
According to [Roku Docs](https://sdkdocs.roku.com/display/sdkdoc/ifAppInfo#ifAppInfo-GetTitle()AsString) `app_info.GetTitle()` should return "the title value from the manifest."

I am not seeing this, at least in development. `app_info.GetTitle()` always returns `roku`.  This really is messing up validation of metrics in dev/test

I'd propose that the `initGAMobile()` take an optional 3rd param that lets you override app name.  